### PR TITLE
ci: hell

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,9 +17,9 @@ jobs:
       FBSDK_VERSION: 2025-03-07
 
       SOL_FILE: foo_opensubsonic.sln
-      MSBUILD_CMD_X86: /maxcpucount /property:RestorePackagesConfig=true,Configuration=Release,Platform=Win32 /target:restore,build
-      MSBUILD_CMD_X64: /maxcpucount /property:RestorePackagesConfig=true,Configuration=Release,Platform=x64   /target:restore,build
-      MSBUILD_CMD_ARM64EC: /maxcpucount /property:RestorePackagesConfig=true,Configuration=Release,Platform=ARM64EC /target:restore,build
+      MSBUILD_CMD_X86: /maxcpucount /property:RestorePackagesConfig=true,Configuration=Release,Platform=Win32,UseOfAtl=Static /target:restore,build
+      MSBUILD_CMD_X64: /maxcpucount /property:RestorePackagesConfig=true,Configuration=Release,Platform=x64,UseOfAtl=Static /target:restore,build
+      MSBUILD_CMD_ARM64EC: /maxcpucount /property:RestorePackagesConfig=true,Configuration=Release,Platform=ARM64EC,UseOfAtl=Static /target:restore,build
 
     steps:
       - name: Checkout repository
@@ -61,9 +61,6 @@ jobs:
             
             $x.Save($filePath)
           }
-
-          cat lib\foobar2000_sdk\libPPUI\libPPUI.vcxproj
-          cat lib\foobar2000_sdk\foobar2000\helpers\foobar2000_sdk_helpers.vcxproj
 
       - name: Setup devcmd
         uses: ilammy/msvc-dev-cmd@v1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,8 +44,8 @@ jobs:
         shell: pwsh
         run: |
           $projectPatches = @{
-            "lib\foobar2000_sdk\libPPUI\libPPUI.vcxproj" = "../..;..;..\..\wtl\Include;%(AdditionalIncludeDirectories)"
-            "lib\foobar2000_sdk\foobar2000\helpers\foobar2000_sdk_helpers.vcxproj" = "..;..\..;..\..\..\wtl\Include;%(AdditionalIncludeDirectories)"
+            "lib\foobar2000_sdk\libPPUI\libPPUI.vcxproj" = '..;../..;..;..\..\wtl\Include;$(VC_AtlmfcIncludePath);%(AdditionalIncludeDirectories)'
+            "lib\foobar2000_sdk\foobar2000\helpers\foobar2000_sdk_helpers.vcxproj" = '..;..\..;..\..\..\wtl\Include;$(VC_AtlmfcIncludePath);%(AdditionalIncludeDirectories)'
           }
 
           foreach ($project in $projectPatches.GetEnumerator()) {

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,7 +45,7 @@ jobs:
         run: |
           $map = @{
             "lib\foobar2000_sdk\libPPUI\libPPUI.vcxproj" = "../..;..;..\..\wtl\Include"
-            "lib\foobar2000_sdk\foobar2000\helpers\foobar2000_sdk_helpers.vcxproj" = "..\..\..\wtl\Include"
+            "lib\foobar2000_sdk\foobar2000\helpers\foobar2000_sdk_helpers.vcxproj" = "..;..\..;..\..\..\wtl\Include"
           }
 
           foreach ($f in $map.Keys) {

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,19 +43,19 @@ jobs:
       - name: Inject Global MSBuild Properties (ATL & WTL)
         shell: pwsh
         run: |
-          $props = @'
+          $targets = @'
           <Project>
             <PropertyGroup>
               <UseOfAtl>Static</UseOfAtl>
             </PropertyGroup>
             <ItemDefinitionGroup>
               <ClCompile>
-                <AdditionalIncludeDirectories>$(MSBuildThisFileDirectory)lib\wtl\Include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+                <AdditionalIncludeDirectories>$(MSBuildThisFileDirectory)lib\wtl\Include;$(VC_ATLMFC_IncludePath);%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
               </ClCompile>
             </ItemDefinitionGroup>
           </Project>
           '@
-          Set-Content -Path "Directory.Build.props" -Value $props -Encoding utf8
+          Set-Content -Path "Directory.Build.targets" -Value $targets -Encoding utf8
 
       - name: Setup devcmd
         uses: ilammy/msvc-dev-cmd@v1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -87,12 +87,25 @@ jobs:
           & $vsInstaller modify `
             --installPath "$installPath" `
             --add Microsoft.VisualStudio.Component.VC.ATL `
+            --add Microsoft.VisualStudio.Component.VC.ATLMFC `
             --add Microsoft.VisualStudio.Component.VC.ATL.ARM64 `
+            --add Microsoft.VisualStudio.Component.VC.MFC.ARM64 `
+            --add Microsoft.VisualStudio.Component.VC.14.29.16.11.ATL `
+            --add Microsoft.VisualStudio.Component.VC.14.29.16.11.MFC `
+            --add Microsoft.VisualStudio.Component.VC.14.29.16.11.ATL.ARM64 `
+            --add Microsoft.VisualStudio.Component.VC.14.29.16.11.MFC.ARM64 `
             --quiet --norestart --wait
 
           if ($LASTEXITCODE -ne 0) {
             throw "Visual Studio component installation failed with exit code $LASTEXITCODE"
           }
+
+          $atlHeaders = Get-ChildItem -Path (Join-Path $installPath "VC\Tools\MSVC") -Filter atlbase.h -Recurse -ErrorAction SilentlyContinue
+          if (-not $atlHeaders) {
+            throw "ATL headers are still missing after component installation"
+          }
+
+          $atlHeaders | Select-Object -ExpandProperty FullName
 
       - name: Setup devcmd
         uses: ilammy/msvc-dev-cmd@v1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,9 +17,9 @@ jobs:
       FBSDK_VERSION: 2025-03-07
 
       SOL_FILE: foo_opensubsonic.sln
-      MSBUILD_CMD_X86: /maxcpucount /p:RestorePackagesConfig=true /p:Configuration=Release /p:Platform=Win32 /t:restore,build
-      MSBUILD_CMD_X64: /maxcpucount /p:RestorePackagesConfig=true /p:Configuration=Release /p:Platform=x64 /t:restore,build
-      MSBUILD_CMD_ARM64EC: /maxcpucount /p:RestorePackagesConfig=true /p:Configuration=Release /p:Platform=ARM64EC /t:restore,build
+      MSBUILD_CMD_X86: /maxcpucount /property:RestorePackagesConfig=true,Configuration=Release,Platform=Win32,UseOfAtl=Static /target:restore,build
+      MSBUILD_CMD_X64: /maxcpucount /property:RestorePackagesConfig=true,Configuration=Release,Platform=x64,UseOfAtl=Static /target:restore,build
+      MSBUILD_CMD_ARM64EC: /maxcpucount /property:RestorePackagesConfig=true,Configuration=Release,Platform=ARM64EC,UseOfAtl=Static /target:restore,build
 
     steps:
       - name: Checkout repository
@@ -40,22 +40,38 @@ jobs:
 
           dir lib
 
-      - name: Inject Global MSBuild Properties (ATL & WTL)
+      - name: Patch SDK
         shell: pwsh
         run: |
-          $targets = @'
-          <Project>
-            <PropertyGroup>
-              <UseOfAtl>Static</UseOfAtl>
-            </PropertyGroup>
-            <ItemDefinitionGroup>
-              <ClCompile>
-                <AdditionalIncludeDirectories>$(MSBuildThisFileDirectory)lib\wtl\Include;$(VC_ATLMFC_IncludePath);%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
-              </ClCompile>
-            </ItemDefinitionGroup>
-          </Project>
-          '@
-          Set-Content -Path "Directory.Build.targets" -Value $targets -Encoding utf8
+          $projectPatches = @{
+            "lib\foobar2000_sdk\libPPUI\libPPUI.vcxproj" = "../..;..;..\..\wtl\Include;%(AdditionalIncludeDirectories)"
+            "lib\foobar2000_sdk\foobar2000\helpers\foobar2000_sdk_helpers.vcxproj" = "..;..\..;..\..\..\wtl\Include;%(AdditionalIncludeDirectories)"
+          }
+
+          foreach ($project in $projectPatches.GetEnumerator()) {
+            $filePath = Resolve-Path $project.Key
+
+            [xml]$x = Get-Content $filePath
+            $ns = New-Object System.Xml.XmlNamespaceManager($x.NameTable)
+            $ns.AddNamespace("msb", "http://schemas.microsoft.com/developer/msbuild/2003")
+            $msbuildNs = $ns.LookupNamespace("msb")
+
+            $x.SelectNodes("//msb:ClCompile/msb:AdditionalIncludeDirectories", $ns) | ForEach-Object {
+              $_.InnerText = $project.Value
+            }
+
+            $x.SelectNodes("//msb:PropertyGroup[@Label='Configuration']", $ns) | ForEach-Object {
+              $useOfAtl = $_.SelectSingleNode("msb:UseOfAtl", $ns)
+              if ($null -eq $useOfAtl) {
+                $useOfAtl = $x.CreateElement("UseOfAtl", $msbuildNs)
+                [void]$_.AppendChild($useOfAtl)
+              }
+
+              $useOfAtl.InnerText = "Static"
+            }
+
+            $x.Save($filePath)
+          }
 
       - name: Setup devcmd
         uses: ilammy/msvc-dev-cmd@v1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,9 +17,9 @@ jobs:
       FBSDK_VERSION: 2025-03-07
 
       SOL_FILE: foo_opensubsonic.sln
-      MSBUILD_CMD_X86: /maxcpucount /property:RestorePackagesConfig=true,Configuration=Release,Platform=Win32,UseOfAtl=Static /target:restore,build
-      MSBUILD_CMD_X64: /maxcpucount /property:RestorePackagesConfig=true,Configuration=Release,Platform=x64,UseOfAtl=Static /target:restore,build
-      MSBUILD_CMD_ARM64EC: /maxcpucount /property:RestorePackagesConfig=true,Configuration=Release,Platform=ARM64EC,UseOfAtl=Static /target:restore,build
+      MSBUILD_CMD_X86: /maxcpucount /p:RestorePackagesConfig=true /p:Configuration=Release /p:Platform=Win32 /t:restore,build
+      MSBUILD_CMD_X64: /maxcpucount /p:RestorePackagesConfig=true /p:Configuration=Release /p:Platform=x64 /t:restore,build
+      MSBUILD_CMD_ARM64EC: /maxcpucount /p:RestorePackagesConfig=true /p:Configuration=Release /p:Platform=ARM64EC /t:restore,build
 
     steps:
       - name: Checkout repository
@@ -40,27 +40,22 @@ jobs:
 
           dir lib
 
-      - name: Patch SDK
+      - name: Inject Global MSBuild Properties (ATL & WTL)
         shell: pwsh
         run: |
-          $map = @{
-            "lib\foobar2000_sdk\libPPUI\libPPUI.vcxproj" = "../..;..;..\..\wtl\Include;%(AdditionalIncludeDirectories)"
-            "lib\foobar2000_sdk\foobar2000\helpers\foobar2000_sdk_helpers.vcxproj" = "..;..\..;..\..\..\wtl\Include;%(AdditionalIncludeDirectories)"
-          }
-
-          foreach ($f in $map.Keys) {
-            $filePath = Resolve-Path $f 
-
-            [xml]$x = Get-Content $filePath
-            $ns = New-Object System.Xml.XmlNamespaceManager($x.NameTable)
-            $ns.AddNamespace("msb", "http://schemas.microsoft.com/developer/msbuild/2003")
-            
-            $x.SelectNodes("//msb:ClCompile/msb:AdditionalIncludeDirectories", $ns) | ForEach-Object { 
-                $_.InnerText = $map[$f] 
-            }
-            
-            $x.Save($filePath)
-          }
+          $props = @'
+          <Project>
+            <PropertyGroup>
+              <UseOfAtl>Static</UseOfAtl>
+            </PropertyGroup>
+            <ItemDefinitionGroup>
+              <ClCompile>
+                <AdditionalIncludeDirectories>$(MSBuildThisFileDirectory)lib\wtl\Include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+              </ClCompile>
+            </ItemDefinitionGroup>
+          </Project>
+          '@
+          Set-Content -Path "Directory.Build.props" -Value $props -Encoding utf8
 
       - name: Setup devcmd
         uses: ilammy/msvc-dev-cmd@v1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,8 +43,6 @@ jobs:
       - name: Patch SDK
         shell: pwsh
         run: |
-          $ns = @{msb="http://schemas.microsoft.com/developer/msbuild/2003"}
-
           $map = @{
             "lib\foobar2000_sdk\libPPUI\libPPUI.vcxproj" = "../..;..;..\..\wtl\Include"
             "lib\foobar2000_sdk\foobar2000\helpers\foobar2000_sdk_helpers.vcxproj" = "..\..\..\wtl\Include"
@@ -52,9 +50,9 @@ jobs:
 
           foreach ($f in $map.Keys) {
             [xml]$x = Get-Content $f
-            $x.SelectNodes("//msb:AdditionalIncludeDirectories", $ns) | % {
-              $_.InnerText = $map[$f]
-            }
+            $ns = New-Object System.Xml.XmlNamespaceManager($x.NameTable)
+            $ns.AddNamespace("msb", "http://schemas.microsoft.com/developer/msbuild/2003")
+            $x.SelectNodes("//msb:ClCompile/msb:AdditionalIncludeDirectories", $ns) | % { $_.InnerText = $map[$f] }
             $x.Save($f)
           }
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,6 +62,9 @@ jobs:
             $x.Save($filePath)
           }
 
+          cat lib\foobar2000_sdk\libPPUI\libPPUI.vcxproj
+          cat lib\foobar2000_sdk\foobar2000\helpers\foobar2000_sdk_helpers.vcxproj
+
       - name: Setup devcmd
         uses: ilammy/msvc-dev-cmd@v1
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,16 +44,22 @@ jobs:
         shell: pwsh
         run: |
           $map = @{
-            "lib\foobar2000_sdk\libPPUI\libPPUI.vcxproj" = "../..;..;..\..\wtl\Include"
-            "lib\foobar2000_sdk\foobar2000\helpers\foobar2000_sdk_helpers.vcxproj" = "..;..\..;..\..\..\wtl\Include"
+            "lib\foobar2000_sdk\libPPUI\libPPUI.vcxproj" = "../..;..;..\..\wtl\Include;%(AdditionalIncludeDirectories)"
+            "lib\foobar2000_sdk\foobar2000\helpers\foobar2000_sdk_helpers.vcxproj" = "..;..\..;..\..\..\wtl\Include;%(AdditionalIncludeDirectories)"
           }
 
           foreach ($f in $map.Keys) {
-            [xml]$x = Get-Content $f
+            $filePath = Resolve-Path $f 
+
+            [xml]$x = Get-Content $filePath
             $ns = New-Object System.Xml.XmlNamespaceManager($x.NameTable)
             $ns.AddNamespace("msb", "http://schemas.microsoft.com/developer/msbuild/2003")
-            $x.SelectNodes("//msb:ClCompile/msb:AdditionalIncludeDirectories", $ns) | % { $_.InnerText = $map[$f] }
-            $x.Save($f)
+            
+            $x.SelectNodes("//msb:ClCompile/msb:AdditionalIncludeDirectories", $ns) | ForEach-Object { 
+                $_.InnerText = $map[$f] 
+            }
+            
+            $x.Save($filePath)
           }
 
       - name: Setup devcmd

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -73,6 +73,27 @@ jobs:
             $x.Save($filePath)
           }
 
+      - name: Install ATL components
+        shell: pwsh
+        run: |
+          $vswhere = Join-Path ${env:ProgramFiles(x86)} "Microsoft Visual Studio\Installer\vswhere.exe"
+          $vsInstaller = Join-Path ${env:ProgramFiles(x86)} "Microsoft Visual Studio\Installer\vs_installer.exe"
+          $installPath = & $vswhere -latest -products * -requires Microsoft.Component.MSBuild -property installationPath
+
+          if (-not $installPath) {
+            throw "Visual Studio installation path not found"
+          }
+
+          & $vsInstaller modify `
+            --installPath "$installPath" `
+            --add Microsoft.VisualStudio.Component.VC.ATL `
+            --add Microsoft.VisualStudio.Component.VC.ATL.ARM64 `
+            --quiet --norestart --wait
+
+          if ($LASTEXITCODE -ne 0) {
+            throw "Visual Studio component installation failed with exit code $LASTEXITCODE"
+          }
+
       - name: Setup devcmd
         uses: ilammy/msvc-dev-cmd@v1
 

--- a/src/foo_opensubsonic.vcxproj
+++ b/src/foo_opensubsonic.vcxproj
@@ -145,7 +145,7 @@
       <PrecompiledHeader>Use</PrecompiledHeader>
       <WarningLevel>Level3</WarningLevel>
       <LanguageStandard>stdcpp20</LanguageStandard>
-      <AdditionalIncludeDirectories>..\lib\foobar2000_sdk\foobar2000;..\lib\foobar2000_sdk\;...\lib\foobar2000_sdk\libPPUI;..\lib\WTL\Include;..\lib\nlohmann;..\lib;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>..\lib\foobar2000_sdk\foobar2000;..\lib\foobar2000_sdk\;...\lib\foobar2000_sdk\libPPUI;..\lib\wtl\Include;..\lib\nlohmann;..\lib;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <Optimization>Disabled</Optimization>
       <PreprocessorDefinitions>DEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <RuntimeLibrary>MultiThreadedDebugDLL</RuntimeLibrary>
@@ -160,7 +160,7 @@
       <PrecompiledHeader>Use</PrecompiledHeader>
       <WarningLevel>Level3</WarningLevel>
       <LanguageStandard>stdcpp20</LanguageStandard>
-      <AdditionalIncludeDirectories>..\lib\foobar2000_sdk\foobar2000;..\lib\foobar2000_sdk\;...\lib\foobar2000_sdk\libPPUI;..\lib\WTL\Include;..\lib\nlohmann;..\lib;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>..\lib\foobar2000_sdk\foobar2000;..\lib\foobar2000_sdk\;...\lib\foobar2000_sdk\libPPUI;..\lib\wtl\Include;..\lib\nlohmann;..\lib;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <Optimization>Disabled</Optimization>
       <PreprocessorDefinitions>DEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <RuntimeLibrary>MultiThreadedDebugDLL</RuntimeLibrary>
@@ -175,7 +175,7 @@
       <PrecompiledHeader>Use</PrecompiledHeader>
       <WarningLevel>Level3</WarningLevel>
       <LanguageStandard>stdcpp20</LanguageStandard>
-      <AdditionalIncludeDirectories>..\lib\foobar2000_sdk\foobar2000;..\lib\foobar2000_sdk\;...\lib\foobar2000_sdk\libPPUI;..\lib\WTL\Include;..\lib\nlohmann;..\lib;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>..\lib\foobar2000_sdk\foobar2000;..\lib\foobar2000_sdk\;...\lib\foobar2000_sdk\libPPUI;..\lib\wtl\Include;..\lib\nlohmann;..\lib;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <Optimization>Disabled</Optimization>
       <PreprocessorDefinitions>DEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <RuntimeLibrary>MultiThreadedDebugDLL</RuntimeLibrary>
@@ -190,7 +190,7 @@
       <PrecompiledHeader>Use</PrecompiledHeader>
       <WarningLevel>Level3</WarningLevel>
       <LanguageStandard>stdcpp20</LanguageStandard>
-      <AdditionalIncludeDirectories>..\lib\foobar2000_sdk\foobar2000;..\lib\foobar2000_sdk\;...\lib\foobar2000_sdk\libPPUI;..\lib\WTL\Include;..\lib\nlohmann;..\lib;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>..\lib\foobar2000_sdk\foobar2000;..\lib\foobar2000_sdk\;...\lib\foobar2000_sdk\libPPUI;..\lib\wtl\Include;..\lib\nlohmann;..\lib;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <Optimization>Disabled</Optimization>
       <PreprocessorDefinitions>DEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <RuntimeLibrary>MultiThreadedDebugDLL</RuntimeLibrary>
@@ -205,7 +205,7 @@
       <WarningLevel>Level3</WarningLevel>
       <PrecompiledHeader>Use</PrecompiledHeader>
       <LanguageStandard>stdcpp20</LanguageStandard>
-      <AdditionalIncludeDirectories>..\lib\foobar2000_sdk\foobar2000;..\lib\foobar2000_sdk\;...\lib\foobar2000_sdk\libPPUI;..\lib\WTL\Include;..\lib\nlohmann;..\lib;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>..\lib\foobar2000_sdk\foobar2000;..\lib\foobar2000_sdk\;...\lib\foobar2000_sdk\libPPUI;..\lib\wtl\Include;..\lib\nlohmann;..\lib;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <PreprocessorDefinitions>NDEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
     </ClCompile>
     <Link>
@@ -221,7 +221,7 @@
       <WarningLevel>Level3</WarningLevel>
       <PrecompiledHeader>Use</PrecompiledHeader>
       <LanguageStandard>stdcpp20</LanguageStandard>
-      <AdditionalIncludeDirectories>..\lib\foobar2000_sdk\foobar2000;..\lib\foobar2000_sdk\;...\lib\foobar2000_sdk\libPPUI;..\lib\WTL\Include;..\lib\nlohmann;..\lib;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>..\lib\foobar2000_sdk\foobar2000;..\lib\foobar2000_sdk\;...\lib\foobar2000_sdk\libPPUI;..\lib\wtl\Include;..\lib\nlohmann;..\lib;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <PreprocessorDefinitions>NDEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
     </ClCompile>
     <Link>
@@ -237,7 +237,7 @@
       <WarningLevel>Level3</WarningLevel>
       <PrecompiledHeader>Use</PrecompiledHeader>
       <LanguageStandard>stdcpp20</LanguageStandard>
-      <AdditionalIncludeDirectories>..\lib\foobar2000_sdk\foobar2000;..\lib\foobar2000_sdk\;...\lib\foobar2000_sdk\libPPUI;..\lib\WTL\Include;..\lib\nlohmann;..\lib;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>..\lib\foobar2000_sdk\foobar2000;..\lib\foobar2000_sdk\;...\lib\foobar2000_sdk\libPPUI;..\lib\wtl\Include;..\lib\nlohmann;..\lib;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <PreprocessorDefinitions>NDEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
     </ClCompile>
     <Link>
@@ -253,7 +253,7 @@
       <WarningLevel>Level3</WarningLevel>
       <PrecompiledHeader>Use</PrecompiledHeader>
       <LanguageStandard>stdcpp20</LanguageStandard>
-      <AdditionalIncludeDirectories>..\lib\foobar2000_sdk\foobar2000;..\lib\foobar2000_sdk\;...\lib\foobar2000_sdk\libPPUI;..\lib\WTL\Include;..\lib\nlohmann;..\lib;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>..\lib\foobar2000_sdk\foobar2000;..\lib\foobar2000_sdk\;...\lib\foobar2000_sdk\libPPUI;..\lib\wtl\Include;..\lib\nlohmann;..\lib;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <PreprocessorDefinitions>NDEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
     </ClCompile>
     <Link>


### PR DESCRIPTION
close after done ci

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Improved CI XML patching to operate per-file, target fewer XML elements, and create fresh XML context per document to reduce unintended edits.
  * Ensure a UseOfAtl property exists and is set to Static for relevant build configurations; preserve existing include entries when patching.
  * Added CI step to install ATL components into the latest IDE when present, with explicit failure on missing installer.
  * Normalized include-path casing and strengthened file path resolution when saving updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->