### PR TITLE
added support for folder playback with ui(tested only on gonic)

### DIFF
--- a/src/folder_actions.cpp
+++ b/src/folder_actions.cpp
@@ -1,0 +1,97 @@
+﻿#include "stdafx.h"
+#include "folder_actions.h"
+#include "service_locator.h"
+#include "utils/track_path_util.h"
+
+#include <SDK/metadb.h>
+#include <SDK/playlist.h>
+
+namespace subsonic::folder_actions {
+
+void register_directory_tracks_metadata(const std::vector<cached_track_metadata> &tracks) {
+	auto &repo = service_locator::metadata_repository();
+	for (const auto &track : tracks) {
+		if (track.is_valid()) {
+			repo.publish(track);
+		}
+	}
+}
+
+void play_folder_as_playlist(const char *folder_name, const std::vector<cached_track_metadata> &tracks) {
+	pfc::string8 playlist_name = "[Folder] ";
+	if (folder_name != nullptr && *folder_name != '\0') {
+		playlist_name += folder_name;
+	} else {
+		playlist_name += "Unknown";
+	}
+	
+	metadb_handle_list handles;
+	auto metadb_api = metadb::get();
+	for (const auto &track : tracks) {
+		if (!track.is_valid()) {
+			continue;
+		}
+		
+		pfc::string8 path = track_path_util::make_subsonic_path(track.track_id);
+		auto handle = metadb_api->handle_create(path, 0);
+		if (handle.is_valid()) {
+			handles.add_item(handle);
+		}
+	}
+
+	auto pm = playlist_manager::get();
+	
+	t_size pl_index = pm->find_playlist(playlist_name);
+	if (pl_index == SIZE_MAX) {
+		pl_index = pm->create_playlist(playlist_name, SIZE_MAX, SIZE_MAX);
+	}
+
+	if (pl_index != SIZE_MAX) {
+		pm->playlist_clear(pl_index);
+		
+		if (handles.get_count() > 0) {
+			pm->playlist_add_items(pl_index, handles, pfc::bit_array_false());
+		}
+		
+		pm->set_active_playlist(pl_index);
+		pm->set_playing_playlist(pl_index);
+		
+		if (handles.get_count() > 0) {
+			pm->playlist_execute_default_action(pl_index, 0);
+		}
+	}
+}
+
+void play_or_enqueue_track(const cached_track_metadata &track, bool enqueue_only) {
+	if (!track.is_valid()) {
+		return;
+	}
+
+	auto metadb_api = metadb::get();
+	pfc::string8 path = track_path_util::make_subsonic_path(track.track_id);
+	auto handle = metadb_api->handle_create(path, 0);
+	if (!handle.is_valid()) {
+		return;
+	}
+
+	metadb_handle_list handles;
+	handles.add_item(handle);
+
+	auto pm = playlist_manager::get();
+	t_size pl_index = pm->get_active_playlist();
+	
+	if (pl_index == SIZE_MAX) {
+		pl_index = pm->create_playlist("OpenSubsonic", SIZE_MAX, SIZE_MAX);
+		pm->set_active_playlist(pl_index);
+	}
+
+	t_size item_index = pm->playlist_get_item_count(pl_index);
+	pm->playlist_add_items(pl_index, handles, pfc::bit_array_false());
+
+	if (!enqueue_only) {
+		pm->set_playing_playlist(pl_index);
+		pm->playlist_execute_default_action(pl_index, item_index);
+	}
+}
+
+} // namespace subsonic::folder_actions

--- a/src/folder_actions.h
+++ b/src/folder_actions.h
@@ -1,0 +1,20 @@
+﻿#pragma once
+
+#include "types.h"
+#include <vector>
+
+namespace subsonic::folder_actions {
+
+// Register fetched directory tracks in the metadata repository
+// Publishes them to the local cache and hints them to metadb_io for instant UI updates
+void register_directory_tracks_metadata(const std::vector<cached_track_metadata> &tracks);
+
+// Creates or replaces a playlist with the folder contents and starts playback
+// Replaces the "[Folder] <folder_name>" playlist if it already exists
+void play_folder_as_playlist(const char *folder_name, const std::vector<cached_track_metadata> &tracks);
+
+// Adds a single track to the currently active playlist
+// If enqueue_only is false, it immediately starts playback of the added track
+void play_or_enqueue_track(const cached_track_metadata &track, bool enqueue_only);
+
+} // namespace subsonic::folder_actions

--- a/src/folder_types.cpp
+++ b/src/folder_types.cpp
@@ -1,0 +1,2 @@
+﻿#include "stdafx.h"
+#include "folder_types.h"

--- a/src/folder_types.h
+++ b/src/folder_types.h
@@ -1,0 +1,33 @@
+﻿#pragma once
+
+#include "types.h"
+
+#include <vector>
+#include <optional>
+
+namespace subsonic::folder {
+
+struct music_folder {
+	pfc::string8 id;
+	pfc::string8 name;
+};
+
+struct directory_entry {
+	pfc::string8 id;
+	pfc::string8 parent_id;
+	pfc::string8 name;
+	bool is_directory = false;
+	size_t song_count = 0;
+	bool has_song_count = false;
+	
+	std::optional<cached_track_metadata> track_meta;
+};
+
+struct folder_directory_result {
+	pfc::string8 id;
+	pfc::string8 name;
+	std::vector<directory_entry> subdirectories;
+	std::vector<cached_track_metadata> child_tracks;
+};
+
+} // namespace subsonic::folder

--- a/src/foo_opensubsonic.vcxproj
+++ b/src/foo_opensubsonic.vcxproj
@@ -268,7 +268,10 @@
     <ClInclude Include="artwork.h" />
     <ClInclude Include="cache.h" />
     <ClInclude Include="config.h" />
+    <ClInclude Include="folder_actions.h" />
+    <ClInclude Include="folder_types.h" />
     <ClInclude Include="foobar_metadata_repository.h" />
+    <ClInclude Include="http\folder_api.h" />
     <ClInclude Include="http\foobar_http_client.h" />
     <ClInclude Include="http\http.h" />
     <ClInclude Include="http\http_client_interface.h" />
@@ -282,6 +285,7 @@
     <ClInclude Include="stdafx.h" />
     <ClInclude Include="sync_types.h" />
     <ClInclude Include="types.h" />
+    <ClInclude Include="ui\folder_view_panel.h" />
     <ClInclude Include="utils\crypto_util.h" />
     <ClInclude Include="utils\string_util.h" />
     <ClInclude Include="utils\subsonic_json_parser.h" />
@@ -296,8 +300,13 @@
     <ClCompile Include="artwork.cpp" />
     <ClCompile Include="cache.cpp" />
     <ClCompile Include="config.cpp" />
+    <ClCompile Include="folder_actions.cpp" />
+    <ClCompile Include="folder_types.cpp" />
     <ClCompile Include="foobar_metadata_repository.cpp" />
     <ClCompile Include="foo_opensubsonic.cpp" />
+    <ClCompile Include="http\folder_api.cpp">
+      <PrecompiledHeader>NotUsing</PrecompiledHeader>
+    </ClCompile>
     <ClCompile Include="http\foobar_http_client.cpp">
       <PrecompiledHeader>NotUsing</PrecompiledHeader>
     </ClCompile>
@@ -320,6 +329,7 @@
       <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Release|ARM64EC'">Create</PrecompiledHeader>
       <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Release|ARM64'">Create</PrecompiledHeader>
     </ClCompile>
+    <ClCompile Include="ui\folder_view_panel.cpp" />
     <ClCompile Include="utils\crypto_util.cpp">
       <PrecompiledHeader>NotUsing</PrecompiledHeader>
     </ClCompile>

--- a/src/http/folder_api.cpp
+++ b/src/http/folder_api.cpp
@@ -1,0 +1,185 @@
+﻿#include "../stdafx.h"
+
+#include "folder_api.h"
+#include "../utils/subsonic_json_parser.h"
+#include "../utils/utils.h"
+#include "../library_sync_engine.h"
+
+namespace subsonic::folder_api {
+
+static void extract_counts(const nlohmann::json &node, folder::directory_entry &entry) {
+	auto songCountIt = node.find("songCount");
+	auto trackCountIt = node.find("trackCount");
+	if (songCountIt != node.end() && songCountIt->is_number()) {
+		entry.song_count = static_cast<size_t>(songCountIt->get<double>());
+		entry.has_song_count = true;
+	} else if (trackCountIt != node.end() && trackCountIt->is_number()) {
+		entry.song_count = static_cast<size_t>(trackCountIt->get<double>());
+		entry.has_song_count = true;
+	} else {
+		entry.song_count = 0;
+		entry.has_song_count = false;
+	}
+}
+
+[[nodiscard]] std::vector<folder::music_folder>
+fetch_music_folders(IHttpClient &http_client, abort_callback &abort) {
+	std::vector<folder::music_folder> result;
+	
+	try {
+		const auto root = http_client.fetch_api("getMusicFolders.view", {}, abort);
+		const auto folders_it = root.find("musicFolders");
+		
+		if (folders_it != root.end()) {
+			if (folders_it->is_object()) {
+				json_parser::for_each_member_item(*folders_it, "musicFolder", [&](const nlohmann::json &node) {
+					folder::music_folder mf;
+					mf.id = json_parser::get_string(node, "id");
+					mf.name = json_parser::get_string(node, "name");
+					if (mf.name.is_empty()) {
+						mf.name = json_parser::get_string(node, "title");
+					}
+					if (!mf.id.is_empty()) {
+						result.push_back(std::move(mf));
+					}
+				});
+			} else if (folders_it->is_array()) {
+				for (const auto &node : *folders_it) {
+					folder::music_folder mf;
+					mf.id = json_parser::get_string(node, "id");
+					mf.name = json_parser::get_string(node, "name");
+					if (!mf.id.is_empty()) {
+						result.push_back(std::move(mf));
+					}
+				}
+			}
+		}
+	} catch (const std::exception &e) {
+		log_error("folder_api", (PFC_string_formatter() << "getMusicFolders.view failed: " << e.what()).c_str());
+	}
+
+	if (result.empty()) {
+		try {
+			const auto root = http_client.fetch_api("getIndexes.view", {}, abort);
+			const auto indexes_it = root.find("indexes");
+			if (indexes_it != root.end()) {
+				folder::music_folder mf;
+				mf.id = "indexes_root";
+				mf.name = "Music Library (Indexes)";
+				result.push_back(std::move(mf));
+			}
+		} catch (const std::exception &e) {
+			log_error("folder_api", (PFC_string_formatter() << "getIndexes.view failed: " << e.what()).c_str());
+		}
+	}
+
+	return result;
+}
+
+[[nodiscard]] folder::folder_directory_result
+fetch_directory(IHttpClient &http_client, const char *dir_id, bool is_root_folder, abort_callback &abort) {
+	folder::folder_directory_result result;
+	
+	if (dir_id == nullptr || *dir_id == '\0') {
+		return result;
+	}
+
+	if (is_root_folder || subsonic::strings_equal(dir_id, "indexes_root")) {
+		try {
+			std::vector<query_param> params;
+			if (!subsonic::strings_equal(dir_id, "indexes_root")) {
+				params.emplace_back("musicFolderId", dir_id);
+			}
+
+			const auto root = http_client.fetch_api("getIndexes.view", params, abort);
+			const auto indexes_it = root.find("indexes");
+			if (indexes_it != root.end() && indexes_it->is_object()) {
+				result.id = dir_id;
+				result.name = "Music Library";
+
+				json_parser::for_each_member_item(*indexes_it, "folder", [&](const nlohmann::json &node) {
+					folder::directory_entry entry;
+					entry.id = json_parser::get_string(node, "id");
+					entry.name = json_parser::get_string(node, "name");
+					entry.is_directory = true;
+					
+					extract_counts(node, entry);
+					if (entry.has_song_count && entry.song_count == 0) return;
+
+					if (!entry.id.is_empty()) {
+						result.subdirectories.push_back(std::move(entry));
+					}
+				});
+
+				json_parser::for_each_member_item(*indexes_it, "index", [&](const nlohmann::json &index_node) {
+					json_parser::for_each_member_item(index_node, "artist", [&](const nlohmann::json &artist_node) {
+						folder::directory_entry entry;
+						entry.id = json_parser::get_string(artist_node, "id");
+						entry.name = json_parser::get_string(artist_node, "name");
+						entry.is_directory = true;
+
+						extract_counts(artist_node, entry);
+						if (entry.has_song_count && entry.song_count == 0) return;
+
+						if (!entry.id.is_empty()) {
+							result.subdirectories.push_back(std::move(entry));
+						}
+					});
+				});
+			}
+		} catch (const std::exception &e) {
+			log_error("folder_api", (PFC_string_formatter() << "getIndexes parse failed: " << e.what()).c_str());
+		}
+		return result;
+	}
+
+	std::vector<query_param> params;
+	params.emplace_back("id", dir_id);
+
+	try {
+		const auto root = http_client.fetch_api("getMusicDirectory.view", params, abort);
+		const auto dir_it = root.find("directory");
+
+		if (dir_it != root.end() && dir_it->is_object()) {
+			result.id = json_parser::get_string(*dir_it, "id");
+			result.name = json_parser::get_string(*dir_it, "name");
+
+			json_parser::for_each_member_item(*dir_it, "child", [&](const nlohmann::json &node) {
+				bool is_dir = false;
+				const auto is_dir_it = node.find("isDir");
+				if (is_dir_it != node.end() && is_dir_it->is_boolean()) {
+					is_dir = is_dir_it->get<bool>();
+				}
+
+				if (is_dir) {
+					folder::directory_entry entry;
+					entry.id = json_parser::get_string(node, "id");
+					entry.parent_id = json_parser::get_string(node, "parent");
+					entry.is_directory = true;
+					entry.name = json_parser::get_string(node, "title");
+					if (entry.name.is_empty()) {
+						entry.name = json_parser::get_string(node, "name");
+					}
+
+					extract_counts(node, entry);
+					if (entry.has_song_count && entry.song_count == 0) return;
+
+					if (!entry.id.is_empty()) {
+						result.subdirectories.push_back(std::move(entry));
+					}
+				} else {
+					auto track_meta = sync::parse_track_metadata(node);
+					if (track_meta.is_valid()) {
+						result.child_tracks.push_back(std::move(track_meta));
+					}
+				}
+			});
+		}
+	} catch (const std::exception &e) {
+		log_error("folder_api", (PFC_string_formatter() << "getMusicDirectory.view failed for id=" << dir_id << ": " << e.what()).c_str());
+	}
+
+	return result;
+}
+
+} // namespace subsonic::folder_api

--- a/src/http/folder_api.h
+++ b/src/http/folder_api.h
@@ -1,0 +1,20 @@
+﻿#pragma once
+
+#include "../folder_types.h"
+#include "http_client_interface.h"
+
+#include <vector>
+
+namespace subsonic::folder_api {
+
+// Fetch top-level music folders from the server
+// Wraps the 'getMusicFolders.view' OpenSubsonic endpoint
+[[nodiscard]] std::vector<folder::music_folder>
+fetch_music_folders(IHttpClient &http_client, abort_callback &abort);
+
+// Fetch the contents of a specific directory by ID
+// If is_root_folder is true, uses getIndexes.view instead of getMusicDirectory.view
+[[nodiscard]] folder::folder_directory_result
+fetch_directory(IHttpClient &http_client, const char *dir_id, bool is_root_folder, abort_callback &abort);
+
+} // namespace subsonic::folder_api

--- a/src/library.cpp
+++ b/src/library.cpp
@@ -29,6 +29,8 @@
 #include <unordered_map>
 #include <unordered_set>
 
+#include "ui/folder_view_panel.h"
+
 namespace {
 
 using json = nlohmann::json;

--- a/src/ui/folder_view_panel.cpp
+++ b/src/ui/folder_view_panel.cpp
@@ -1,0 +1,414 @@
+﻿#include "stdafx.h"
+#include "folder_view_panel.h"
+#include "../folder_actions.h"
+#include "../http/folder_api.h"
+#include "../http/foobar_http_client.h"
+#include "../utils/utils.h"
+#include "../utils/track_path_util.h"
+#include "../config.h"
+
+namespace subsonic::ui {
+
+static const GUID guid_folder_view_panel = { 
+	0x519890a9, 0xb800, 0x4f36, 
+	{ 0xa6, 0x5c, 0x7c, 0xc1, 0x1f, 0x8a, 0x1d, 0x6e } 
+};
+
+enum menu_commands : UINT_PTR {
+	ID_MENU_PLAY_FOLDER = 10001,
+	ID_MENU_REFRESH_FOLDER,
+	ID_MENU_PLAY_TRACK,
+	ID_MENU_ADD_TRACK
+};
+
+folder_view_panel::folder_view_panel(ui_element_config::ptr cfg, ui_element_instance_callback::ptr callback)
+	: m_bMsgHandled(0), m_config(cfg), m_callback(callback),
+	  m_is_alive(std::make_shared<std::atomic<bool>>(true)) {
+}
+
+folder_view_panel::~folder_view_panel() {
+	if (m_is_alive) {
+		*m_is_alive = false;
+	}
+}
+
+void folder_view_panel::initialize_window(HWND parent) {
+	WIN32_OP(Create(parent) != NULL);
+}
+
+HWND folder_view_panel::get_wnd() {
+	return m_hWnd;
+}
+
+void folder_view_panel::set_configuration(ui_element_config::ptr cfg) {
+	m_config = cfg;
+}
+
+ui_element_config::ptr folder_view_panel::get_configuration() {
+	return m_config;
+}
+
+void folder_view_panel::notify(const GUID & what, t_size param1, const void * param2, t_size param2size) {
+	if (what == ui_element_notify_colors_changed) {
+		update_colors();
+	}
+}
+
+GUID folder_view_panel::g_get_guid() {
+	return guid_folder_view_panel;
+}
+
+GUID folder_view_panel::g_get_subclass() {
+	return ui_element_subclass_media_library_viewers;
+}
+
+void folder_view_panel::g_get_name(pfc::string_base &out) {
+	out = "OpenSubsonic Folder View";
+}
+
+ui_element_config::ptr folder_view_panel::g_get_default_configuration() {
+	return ui_element_config::g_create_empty(g_get_guid());
+}
+
+const char *folder_view_panel::g_get_description() {
+	return "Browse and play OpenSubsonic library by folders.";
+}
+
+void folder_view_panel::update_colors() {
+	if (m_callback.is_valid()) {
+		m_tree.SetBkColor(m_callback->query_std_color(ui_color_background));
+		m_tree.SetTextColor(m_callback->query_std_color(ui_color_text));
+	}
+}
+
+int folder_view_panel::OnCreate(LPCREATESTRUCT lpCreateStruct) {
+	m_dark.AddDialogWithControls(*this);
+
+	m_tree.Create(m_hWnd, rcDefault, NULL, 
+				  WS_CHILD | WS_VISIBLE | WS_CLIPSIBLINGS | WS_CLIPCHILDREN | 
+				  TVS_HASBUTTONS | TVS_HASLINES | TVS_LINESATROOT | TVS_SHOWSELALWAYS, 
+				  WS_EX_CLIENTEDGE);
+
+	try {
+		m_selection_holder = ui_selection_manager::get()->acquire();
+	} catch (...) {
+		FB2K_console_formatter() << "[foo_opensubsonic][folder_view] Warning: Failed to acquire selection manager.";
+	}
+
+	update_colors();
+	load_root_folders();
+	return 0;
+}
+
+void folder_view_panel::OnSize(UINT nType, CSize size) {
+	if (m_tree.m_hWnd != NULL) {
+		m_tree.SetWindowPos(NULL, 0, 0, size.cx, size.cy, SWP_NOZORDER | SWP_NOACTIVATE);
+	}
+	SetMsgHandled(FALSE);
+}
+
+void folder_view_panel::OnDestroy() {
+	if (m_is_alive) {
+		*m_is_alive = false;
+	}
+	m_selection_holder.release();
+	m_node_store.clear();
+	SetMsgHandled(FALSE);
+}
+
+HTREEITEM folder_view_panel::insert_tree_node(HTREEITEM hParent, const char *clean_name, const char *id, bool is_root, bool has_children, bool is_track, std::optional<cached_track_metadata> track_meta, size_t initial_track_count) {
+	auto node = std::make_unique<tree_node_data>();
+	node->id = id;
+	node->name = clean_name;
+	node->is_root_music_folder = is_root;
+	node->children_loaded = false;
+	node->is_track = is_track;
+	node->track_meta = track_meta;
+
+	TVINSERTSTRUCT tvis = {};
+	tvis.hParent = hParent;
+	tvis.hInsertAfter = TVI_LAST;
+	tvis.item.mask = TVIF_TEXT | TVIF_PARAM | TVIF_CHILDREN;
+	
+	pfc::string8 display_text = clean_name;
+	if (!is_track && initial_track_count > 0) {
+		display_text << " (" << initial_track_count << ")";
+	}
+
+	pfc::stringcvt::string_os_from_utf8 os_name(display_text);
+	tvis.item.pszText = const_cast<TCHAR *>(os_name.get_ptr());
+	tvis.item.lParam = reinterpret_cast<LPARAM>(node.get());
+	tvis.item.cChildren = has_children ? 1 : 0;
+
+	HTREEITEM hItem = m_tree.InsertItem(&tvis);
+	m_node_store[hItem] = std::move(node);
+	return hItem;
+}
+
+void folder_view_panel::load_root_folders() {
+	m_tree.DeleteAllItems();
+	m_node_store.clear();
+	insert_tree_node(TVI_ROOT, "Loading folders...", "", true, false, false, std::nullopt);
+
+	auto alive = m_is_alive;
+	auto pThis = this; 
+
+	fb2k::splitTask([alive, pThis] {
+		try {
+			if (!*alive) return;
+			
+			auto credentials = subsonic::config::load_server_credentials();
+			if (!credentials.is_configured()) {
+				fb2k::inMainThread([alive, pThis] {
+					if (!*alive) return;
+					pThis->m_tree.DeleteAllItems();
+					pThis->insert_tree_node(TVI_ROOT, "Server not configured in Preferences", "", true, false, false, std::nullopt);
+				});
+				return;
+			}
+
+			subsonic::foobar_http_client standalone_client(credentials);
+			abort_callback_dummy abort;
+			auto folders = folder_api::fetch_music_folders(standalone_client, abort);
+
+			fb2k::inMainThread([alive, pThis, folders = std::move(folders)] {
+				if (!*alive) return;
+
+				pThis->m_tree.DeleteAllItems();
+
+				if (folders.empty()) {
+					pThis->insert_tree_node(TVI_ROOT, "No music folders returned by server", "", true, false, false, std::nullopt);
+					return;
+				}
+
+				for (const auto &folder : folders) {
+					HTREEITEM hItem = pThis->insert_tree_node(TVI_ROOT, folder.name.c_str(), folder.id.c_str(), true, true, false, std::nullopt);
+					pThis->m_tree.Expand(hItem, TVE_EXPAND);
+				}
+			});
+		} catch (const std::exception &e) {
+			fb2k::inMainThread([alive, pThis, err = pfc::string8(e.what())] {
+				if (!*alive) return;
+				pThis->m_tree.DeleteAllItems();
+				pThis->insert_tree_node(TVI_ROOT, (PFC_string_formatter() << "Error: " << err).c_str(), "", true, false, false, std::nullopt);
+			});
+		}
+	});
+}
+
+void folder_view_panel::expand_folder_node(HTREEITEM hItem, tree_node_data *data) {
+	if (data == nullptr || data->children_loaded || data->id.is_empty()) {
+		return;
+	}
+	
+	if (m_fetching_nodes.count(data->id.c_str())) {
+		return; 
+	}
+	m_fetching_nodes.insert(data->id.c_str());
+	
+	insert_tree_node(hItem, "Loading...", "", false, false, false, std::nullopt, 0);
+
+	auto alive = m_is_alive;
+	auto pThis = this;
+	pfc::string8 node_id = data->id;
+	bool is_root = data->is_root_music_folder;
+	
+	fb2k::splitTask([alive, pThis, hItem, node_id, is_root] {
+		try {
+			if (!*alive) return;
+
+			auto credentials = subsonic::config::load_server_credentials();
+			if (!credentials.is_configured()) return;
+
+			subsonic::foobar_http_client standalone_client(credentials);
+			abort_callback_dummy abort;
+			auto dir_result = folder_api::fetch_directory(standalone_client, node_id.c_str(), is_root, abort);
+			
+			std::vector<folder::directory_entry> valid_dirs;
+			for (auto& sub : dir_result.subdirectories) {
+				if (sub.has_song_count && sub.song_count == 0) continue;
+				valid_dirs.push_back(std::move(sub));
+			}
+			dir_result.subdirectories = std::move(valid_dirs);
+			
+			fb2k::inMainThread([alive, pThis, hItem, node_id, dir_result = std::move(dir_result)]() mutable {
+				if (!*alive) return;
+				pThis->m_fetching_nodes.erase(node_id.c_str());
+				
+				tree_node_data* active_data = nullptr;
+				if (pThis->m_node_store.count(hItem)) {
+					active_data = pThis->m_node_store[hItem].get();
+				}
+				if (!active_data || active_data->id != node_id) return;
+				
+				HTREEITEM hChild = pThis->m_tree.GetChildItem(hItem);
+				while (hChild != NULL) {
+					HTREEITEM hNext = pThis->m_tree.GetNextSiblingItem(hChild);
+					pThis->m_tree.DeleteItem(hChild);
+					hChild = hNext;
+				}
+
+				if (dir_result.child_tracks.empty() && dir_result.subdirectories.empty()) {
+					active_data->children_loaded = true;
+					return;
+				}
+
+				active_data->folder_tracks = dir_result.child_tracks;
+				folder_actions::register_directory_tracks_metadata(dir_result.child_tracks);
+				
+				for (const auto &sub : dir_result.subdirectories) {
+					pThis->insert_tree_node(hItem, sub.name.c_str(), sub.id.c_str(), false, true, false, std::nullopt, sub.song_count);
+				}
+				
+				for (const auto &track : dir_result.child_tracks) {
+					pfc::string8 display_name = track.title;
+					if (display_name.is_empty()) display_name = track.track_id;
+					
+					if (!track.suffix.is_empty() && !subsonic::ends_with_ascii_nocase(display_name.c_str(), track.suffix.c_str())) {
+						display_name << "." << track.suffix;
+					}
+					
+					pThis->insert_tree_node(hItem, display_name.c_str(), track.track_id.c_str(), false, false, true, track, 0);
+				}
+				
+				pfc::string8 folder_label = active_data->name;
+				if (!dir_result.child_tracks.empty()) {
+					folder_label << " (" << dir_result.child_tracks.size() << ")";
+				}
+				pfc::stringcvt::string_os_from_utf8 os_folder_label(folder_label);
+
+				TVITEM item = {};
+				item.mask = TVIF_TEXT;
+				item.hItem = hItem;
+				item.pszText = const_cast<TCHAR*>(os_folder_label.get_ptr());
+				pThis->m_tree.SetItem(&item);
+
+				active_data->children_loaded = true;
+				pThis->m_tree.Expand(hItem, TVE_EXPAND);
+			});
+		} catch (const std::exception &e) {
+			fb2k::inMainThread([alive, pThis, hItem, node_id, err = pfc::string8(e.what())] {
+				if (!*alive) return;
+				pThis->m_fetching_nodes.erase(node_id.c_str());
+				
+				HTREEITEM hChild = pThis->m_tree.GetChildItem(hItem);
+				while (hChild != NULL) {
+					HTREEITEM hNext = pThis->m_tree.GetNextSiblingItem(hChild);
+					pThis->m_tree.DeleteItem(hChild);
+					hChild = hNext;
+				}
+				pThis->insert_tree_node(hItem, (PFC_string_formatter() << "Error: " << err).c_str(), "", false, false, false, std::nullopt);
+			});
+		}
+	});
+}
+
+void folder_view_panel::select_folder_node(HTREEITEM hItem, tree_node_data *data) {
+	if (data == nullptr || data->id.is_empty()) {
+		return;
+	}
+
+	m_current_folder_id = data->id;
+	m_current_folder_name = data->name;
+
+	if (!m_selection_holder.is_valid()) {
+		return;
+	}
+
+	metadb_handle_list handles;
+
+	if (data->is_track && data->track_meta.has_value()) {
+		folder_actions::register_directory_tracks_metadata({ data->track_meta.value() });
+		auto handle = static_api_ptr_t<metadb>()->handle_create(subsonic::track_path_util::make_subsonic_path(data->track_meta.value().track_id.c_str()), 0);
+		if (handle.is_valid()) handles.add_item(handle);
+	} else if (data->children_loaded && !data->folder_tracks.empty()) {
+		for (const auto &track : data->folder_tracks) {
+			auto handle = static_api_ptr_t<metadb>()->handle_create(subsonic::track_path_util::make_subsonic_path(track.track_id.c_str()), 0);
+			if (handle.is_valid()) handles.add_item(handle);
+		}
+	}
+
+	m_selection_holder->set_selection(handles);
+}
+
+LRESULT folder_view_panel::OnNotify(int idCtrl, LPNMHDR pnmh) {
+	if (pnmh->hwndFrom == m_tree.m_hWnd) {
+		if (pnmh->code == TVN_ITEMEXPANDINGW || pnmh->code == TVN_ITEMEXPANDINGA) {
+			auto *pnmtv = reinterpret_cast<LPNMTREEVIEW>(pnmh);
+			if (pnmtv->action == TVE_EXPAND) {
+				auto *data = reinterpret_cast<tree_node_data *>(pnmtv->itemNew.lParam);
+				if (data != nullptr) {
+					expand_folder_node(pnmtv->itemNew.hItem, data);
+				}
+			}
+		} else if (pnmh->code == TVN_SELCHANGEDW || pnmh->code == TVN_SELCHANGEDA) {
+			auto *pnmtv = reinterpret_cast<LPNMTREEVIEW>(pnmh);
+			auto *data = reinterpret_cast<tree_node_data *>(pnmtv->itemNew.lParam);
+			if (data != nullptr) {
+				select_folder_node(pnmtv->itemNew.hItem, data);
+			}
+		} else if (pnmh->code == NM_DBLCLK) {
+			HTREEITEM hSel = m_tree.GetSelectedItem();
+			if (hSel != NULL) {
+				auto *data = reinterpret_cast<tree_node_data *>(m_tree.GetItemData(hSel));
+				if (data != nullptr && data->is_track && data->track_meta.has_value()) {
+					folder_actions::play_or_enqueue_track(data->track_meta.value(), false);
+				}
+			}
+		} else if (pnmh->code == TVN_DELETEITEMW || pnmh->code == TVN_DELETEITEMA) {
+			auto *pnmtv = reinterpret_cast<LPNMTREEVIEW>(pnmh);
+			m_node_store.erase(pnmtv->itemOld.hItem);
+		}
+	}
+	return 0;
+}
+
+void folder_view_panel::OnContextMenu(HWND hwnd, CPoint pt) {
+	if (pt.x == -1 && pt.y == -1) {
+		pt = { 0, 0 };
+	}
+
+	if (hwnd == m_tree.m_hWnd || ::IsChild(m_tree.m_hWnd, hwnd)) {
+		HTREEITEM hSel = m_tree.GetSelectedItem();
+		tree_node_data *data = nullptr;
+		if (hSel != NULL) {
+			data = reinterpret_cast<tree_node_data *>(m_tree.GetItemData(hSel));
+		}
+
+		CMenu menu;
+		menu.CreatePopupMenu();
+
+		if (data != nullptr && data->is_track) {
+			menu.AppendMenu(MF_STRING, ID_MENU_PLAY_TRACK, _T("Play Track"));
+			menu.AppendMenu(MF_STRING, ID_MENU_ADD_TRACK, _T("Add to Playlist"));
+		} else {
+			menu.AppendMenu(MF_STRING, ID_MENU_PLAY_FOLDER, _T("Play Folder"));
+			menu.AppendMenu(MF_STRING, ID_MENU_REFRESH_FOLDER, _T("Refresh"));
+		}
+
+		UINT cmd = menu.TrackPopupMenu(TPM_LEFTALIGN | TPM_RIGHTBUTTON | TPM_RETURNCMD, pt.x, pt.y, m_hWnd);
+		
+		if (cmd == ID_MENU_PLAY_FOLDER) {
+			if (data && !data->is_track && data->children_loaded) {
+				folder_actions::play_folder_as_playlist(data->name.c_str(), data->folder_tracks);
+			} else if (data && !data->is_track) {
+				expand_folder_node(hSel, data);
+				folder_actions::play_folder_as_playlist(data->name.c_str(), data->folder_tracks);
+			}
+		} else if (cmd == ID_MENU_REFRESH_FOLDER) {
+			load_root_folders();
+		} else if (cmd == ID_MENU_PLAY_TRACK) {
+			if (data && data->is_track && data->track_meta.has_value()) {
+				folder_actions::play_or_enqueue_track(data->track_meta.value(), false);
+			}
+		} else if (cmd == ID_MENU_ADD_TRACK) {
+			if (data && data->is_track && data->track_meta.has_value()) {
+				folder_actions::play_or_enqueue_track(data->track_meta.value(), true);
+			}
+		}
+	}
+}
+
+static service_factory_single_t<folder_view_panel_impl> g_folder_view_panel_impl_factory;
+
+} // namespace subsonic::ui

--- a/src/ui/folder_view_panel.h
+++ b/src/ui/folder_view_panel.h
@@ -1,0 +1,96 @@
+﻿#pragma once
+
+#include "../types.h"
+
+#include <SDK/ui_element.h>
+#include <SDK/ui.h>
+#include <helpers/atl-misc.h>
+#include <helpers/DarkMode.h>
+
+#include <atlbase.h>
+#include <atlapp.h>
+#include <atlcrack.h>
+#include <atlctrls.h>
+
+#include <memory>
+#include <vector>
+#include <atomic>
+#include <optional>
+#include <unordered_map>
+#include <unordered_set>
+#include <string>
+
+namespace subsonic::ui {
+
+struct tree_node_data {
+	pfc::string8 id;
+	pfc::string8 name;
+	bool is_root_music_folder = false;
+	bool children_loaded = false;
+	bool is_track = false;
+	std::optional<cached_track_metadata> track_meta;
+	std::vector<cached_track_metadata> folder_tracks;
+};
+
+class folder_view_panel : public ui_element_instance, public CWindowImpl<folder_view_panel> {
+public:
+	DECLARE_WND_CLASS_EX(_T("foo_opensubsonic_folder_view"), CS_VREDRAW | CS_HREDRAW, (-1));
+
+	folder_view_panel(ui_element_config::ptr cfg, ui_element_instance_callback::ptr callback);
+	~folder_view_panel() override;
+
+	void initialize_window(HWND parent);
+
+	HWND get_wnd() override;
+	void set_configuration(ui_element_config::ptr cfg) override;
+	ui_element_config::ptr get_configuration() override;
+	void notify(const GUID & what, t_size param1, const void * param2, t_size param2size) override;
+
+	static GUID g_get_guid();
+	static GUID g_get_subclass();
+	static void g_get_name(pfc::string_base &out);
+	static ui_element_config::ptr g_get_default_configuration();
+	static const char *g_get_description();
+
+	BEGIN_MSG_MAP_EX(folder_view_panel)
+		MSG_WM_CREATE(OnCreate)
+		MSG_WM_SIZE(OnSize)
+		MSG_WM_DESTROY(OnDestroy)
+		MSG_WM_NOTIFY(OnNotify)
+		MSG_WM_CONTEXTMENU(OnContextMenu)
+	END_MSG_MAP()
+
+private:
+	int OnCreate(LPCREATESTRUCT lpCreateStruct);
+	void OnSize(UINT nType, CSize size);
+	void OnDestroy();
+	LRESULT OnNotify(int idCtrl, LPNMHDR pnmh);
+	void OnContextMenu(HWND hwnd, CPoint pt);
+
+	void update_colors();
+	void load_root_folders();
+	void expand_folder_node(HTREEITEM hItem, tree_node_data *data);
+	void select_folder_node(HTREEITEM hItem, tree_node_data *data);
+
+	HTREEITEM insert_tree_node(HTREEITEM hParent, const char *clean_name, const char *id, bool is_root, bool has_children, bool is_track, std::optional<cached_track_metadata> track_meta, size_t initial_track_count = 0);
+
+	ui_element_config::ptr m_config;
+	ui_element_instance_callback::ptr m_callback;
+
+	CTreeViewCtrl m_tree;
+	fb2k::CDarkModeHooks m_dark;
+
+	ui_selection_holder::ptr m_selection_holder;
+
+	std::shared_ptr<std::atomic<bool>> m_is_alive;
+	
+	std::unordered_map<HTREEITEM, std::unique_ptr<tree_node_data>> m_node_store;
+	std::unordered_set<std::string> m_fetching_nodes;
+
+	pfc::string8 m_current_folder_name;
+	pfc::string8 m_current_folder_id;
+};
+
+class folder_view_panel_impl : public ui_element_impl<folder_view_panel> {};
+
+} // namespace subsonic::ui


### PR DESCRIPTION
Added a UI element similar to the one in foobar, it lets you browse your folders from a remote server and play an entire folder or a single file. Tested only on gonic.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a folder browser for exploring music folders and directories.
  * Displays track counts and available metadata while filtering empty folders.
  * Added asynchronous loading with error and configuration status messages.
  * Added playback controls to play folders as playlists or play and enqueue individual tracks.
  * Added context-menu actions and double-click playback support.
  * Added support for retrieving folder and directory contents from compatible servers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->